### PR TITLE
MCP Trust Score

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 [![Firefly](https://infralight-templates-public.s3.amazonaws.com/company-logos/firefly_logo_white.png)](https://firefly.ai)
 
+[![Trust Score](https://archestra.ai/mcp-catalog/api/badge/quality/gofireflyio/firefly-mcp)](https://archestra.ai/mcp-catalog/gofireflyio__firefly-mcp)
+
 # Firefly MCP Server
 
 The Firefly MCP (Model Context Protocol) server is a TypeScript-based server that enables seamless integration with the Firefly platform. It allows you to discover, manage, and codify resources across your Cloud and SaaS accounts connected to Firefly.


### PR DESCRIPTION
Hi!

This PR adds the "Trust Score" badge from our new Open Source MCP catalog.

Our catalog evaluates MCP servers based on technical quality—like protocol feature implementation and dependency health—rather than vanity metrics like GitHub stars.

The scoring process is fully transparent and reproducible:
- Evaluation Script: https://github.com/archestra-ai/website/blob/main/app/app/mcp-catalog/scripts/evaluate-catalog.ts
- Your Server's Page: https://archestra.ai/mcp-catalog/gofireflyio__firefly-mcp

The badge is designed to be respectful to the structure of your readme, example: [![Trust Score](https://archestra.ai/mcp-catalog/api/badge/quality/topoteretes/cognee/cognee-mcp)](https://archestra.ai/mcp-catalog/topoteretes__cognee__cognee-mcp)

Projects like Grafana MCP (https://github.com/grafana/mcp-grafana) are already participating. 

We believe that transparent and truly open source MCP catalog should help the community to identify great MCP servers like yours 😊

We'd appreciate your support by merging this PR!