### PR TITLE
docs: add Fronteir AI hosted deployment option

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,10 @@ The Firefly MCP (Model Context Protocol) server is a TypeScript-based server tha
 - 🔐 Secure Authentication: Uses FIREFLY_ACCESS_KEY and FIREFLY_SECRET_KEY for secure communication
 - 🚀 Easy Integration: Works seamlessly with Claude and Cursor
 
+## Hosted deployment
+
+A hosted deployment is available on [Fronteir AI](https://fronteir.ai/mcp/gofireflyio-firefly-mcp).
+
 ## Prerequisites
 
 - Node.js (v20 or higher)


### PR DESCRIPTION
Love the project!

Adds a short note in the README that a hosted deployment is available on [Fronteir AI](https://fronteir.ai/mcp/gofireflyio-firefly-mcp).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only change that doesn’t affect runtime behavior.
> 
> **Overview**
> Documents an additional **hosted deployment** option by adding a new `Hosted deployment` section in `README.md` linking to Fronteir AI.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ecd504132bc1041df38b517dc82968356fdcf422. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->